### PR TITLE
Add GNU gettext for makemessages command

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y \
 		mysql-client libmysqlclient-dev \
 		postgresql-client libpq-dev \
 		sqlite3 \
+        gettext \
 		gcc \
 	--no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/2.7/onbuild/Dockerfile
+++ b/2.7/onbuild/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
 		mysql-client libmysqlclient-dev \
 		postgresql-client libpq-dev \
 		sqlite3 \
+        gettext \
 		gcc \
 	--no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y \
 		mysql-client libmysqlclient-dev \
 		postgresql-client libpq-dev \
 		sqlite3 \
+        gettext \
 		gcc \
 	--no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/3.4/onbuild/Dockerfile
+++ b/3.4/onbuild/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
 		mysql-client libmysqlclient-dev \
 		postgresql-client libpq-dev \
 		sqlite3 \
+        gettext \
 		gcc \
 	--no-install-recommends && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The `makemessages` command needs GNU gettext (https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#message-files).

Fixes #11.